### PR TITLE
Fix variable type for samples counter

### DIFF
--- a/src_RP2040/main.cpp
+++ b/src_RP2040/main.cpp
@@ -262,7 +262,7 @@ void burstReadAxes(AxisReading &x, AxisReading &y, AxisReading &z)
     z.high = buf[5];
 }
 
-u_int32_t samples=0;
+uint32_t samples = 0;
 // Main loop
 void loop()
 {


### PR DESCRIPTION
## Summary
- fix `samples` counter declaration type in `main.cpp`

## Testing
- `g++ src_RP2040/main.cpp -o /tmp/main.exe` *(fails: Arduino headers missing)*

------
https://chatgpt.com/codex/tasks/task_e_686daa9fbfd8832b853d17f49accf54e